### PR TITLE
Fixed immutable tuple

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1017,7 +1017,7 @@ async def get_directory_list(request):
 
 
 def try_download_and_save_model_info(model_file_path):
-    success = (0, 0, 0) #info, notes, url
+    success = [0, 0, 0] #info, notes, url
     head, _ = os.path.splitext(model_file_path)
     model_info_path = head + model_info_extension
     model_notes_path = head + model_notes_extension


### PR DESCRIPTION
Tuples are immutable in python.
This will trigger errors when some conditions are met in the try_download function.
This fixes them.